### PR TITLE
Monomers ports

### DIFF
--- a/vivarium_readdy/__init__.py
+++ b/vivarium_readdy/__init__.py
@@ -14,7 +14,11 @@ def get_module_version():
 
 
 from .processes.readdy_process import ReaddyProcess  # noqa: F401
-from vivarium.core.registry import emitter_registry  # noqa: F401
+from .util import monomer_ports_schema  # noqa: F401
+from .util import create_monomer_update  # noqa: F401
+from .util import agents_update  # noqa: F401
+
 from .processes.simularium_emitter import SimulariumEmitter  # noqa: F401
+from vivarium.core.registry import emitter_registry
 
 emitter_registry.register("simularium", SimulariumEmitter)

--- a/vivarium_readdy/__init__.py
+++ b/vivarium_readdy/__init__.py
@@ -18,7 +18,7 @@ from .util import monomer_ports_schema  # noqa: F401
 from .util import create_monomer_update  # noqa: F401
 from .util import agents_update  # noqa: F401
 
-from .processes.simularium_emitter import SimulariumEmitter  # noqa: F401
+from .processes.simularium_monomer_emitter import SimulariumMonomerEmitter  # noqa: F401
 from vivarium.core.registry import emitter_registry
 
-emitter_registry.register("simularium", SimulariumEmitter)
+emitter_registry.register("simularium_monomers", SimulariumMonomerEmitter)

--- a/vivarium_readdy/processes/readdy_process.py
+++ b/vivarium_readdy/processes/readdy_process.py
@@ -285,18 +285,19 @@ class ReaddyProcess(Process):
         edges = self.current_particle_edges()
         for index, topology in enumerate(self.simulation.current_topologies):
             particle_ids = []
-            for p in topology.particles:
-                particle_ids.append(p.id)
+            for p_ix, particle in enumerate(topology.particles):
+                particle_ids.append(particle.id)
                 neighbor_ids = []
                 for edge in edges:
-                    if p.id == edge[0]:
+                    if particle.id == edge[0]:
                         neighbor_ids.append(edge[1])
-                    elif p.id == edge[1]:
+                    elif particle.id == edge[1]:
                         neighbor_ids.append(edge[0])
-                result["particles"][p.id] = {
-                    "type_name": p.type,
-                    "position": p.pos,
+                result["particles"][p_ix] = {
+                    "type_name": particle.type,
+                    "position": particle.pos,
                     "neighbor_ids": neighbor_ids,
+                    "radius": self.parameters["particle_radii"].get(particle.type, 1.0),
                 }
             result["topologies"][index] = {
                 "type_name": topology.type,
@@ -304,10 +305,11 @@ class ReaddyProcess(Process):
             }
         # non-topology particles
         for index, particle in enumerate(self.simulation.current_particles):
-            result["particles"][p.id] = {
-                "type_name": p.type,
-                "position": p.pos,
+            result["particles"][index] = {
+                "type_name": particle.type,
+                "position": particle.pos,
                 "neighbor_ids": [],
+                "radius": self.parameters["particle_radii"].get(particle.type, 1.0),
             }
         return result
 
@@ -339,6 +341,7 @@ class ReaddyProcess(Process):
                 "type_name": "C",
                 "position": position,
                 "neighbor_ids": [],
+                "radius": 2.0,
             }
             last_id += 1
         # inert chain particles
@@ -355,6 +358,7 @@ class ReaddyProcess(Process):
                 "type_name": "D",
                 "position": chain_position,
                 "neighbor_ids": neighbor_ids,
+                "radius": 4.0,
             }
             chain_particle_ids.append(particle_id)
             chain_position += 2 * chain_particle_radius * np.random.uniform(3)

--- a/vivarium_readdy/processes/readdy_process.py
+++ b/vivarium_readdy/processes/readdy_process.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from vivarium.core.process import Process
-from vivarium.core.engine import Engine, pf
+from vivarium.core.engine import Engine
 
 from tqdm import tqdm
 import readdy
@@ -376,7 +376,7 @@ class ReaddyProcess(Process):
         }
 
 
-def test_readdy_process():
+def run_readdy_process():
     readdy_process = ReaddyProcess(
         {
             "particle_radii": {
@@ -402,22 +402,15 @@ def test_readdy_process():
             ],
         }
     )
+    composite = readdy_process.generate()
     engine = Engine(
-        processes={"readdy": readdy_process},
-        topology={
-            "readdy": {
-                "box_size": ("box_size",),
-                "topologies": ("topologies",),
-                "particles": ("particles",),
-            }
-        },
+        composite=composite,
         initial_state=readdy_process.initial_state(),
         emitter="simularium",
     )
     engine.update(1.0)  # 10 steps
-    output = engine.emitter.get_data()
-    print(pf(output))
+    engine.emitter.get_data()
 
 
 if __name__ == "__main__":
-    test_readdy_process()
+    run_readdy_process()

--- a/vivarium_readdy/processes/simularium_monomer_emitter.py
+++ b/vivarium_readdy/processes/simularium_monomer_emitter.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, List
 
 from vivarium.core.emitter import Emitter
 
@@ -10,22 +10,16 @@ from simulariumio import (
     AgentData,
     MetaData,
     UnitData,
+    DisplayData,
+    DISPLAY_TYPE,
 )
 
-# TODO add viz type to state?
-VIZ_FOR_CHOICE = {
-    "medyan_active": "fibers",
-    "cytosim_active": "fibers",
-    "readdy_active": "monomers",
-    "init": "fibers",
-}
 
-
-class SimulariumEmitter(Emitter):
+class SimulariumMonomerEmitter(Emitter):
     def __init__(self, config: Dict[str, str]) -> None:
         super().__init__(config)
         self.configuration_data = None
-        self.saved_data: Dict[float, Dict[str, Any]] = {}
+        self.saved_data: List[Dict[str, Any]] = []
 
     def emit(self, data: Dict[str, Any]) -> None:
         """
@@ -37,45 +31,9 @@ class SimulariumEmitter(Emitter):
             self.configuration_data = data["data"]
             assert "processes" in self.configuration_data, "please emit processes"
         if data["table"] == "history":
-            emit_data = data["data"]
-            time = emit_data["time"]
-            self.saved_data[time] = {
-                key: value for key, value in emit_data.items() if key not in ["time"]
-            }
+            self.saved_data.append(data["data"])
 
-    def get_simularium_fibers(
-        self, time, fibers, actin_radius, position_offset, trajectory
-    ):
-        """
-        Shape fiber state data into Simularium fiber agents
-        """
-        print(f"      {position_offset}")
-        n_agents = 0
-        time_index = len(trajectory["times"])
-        trajectory["times"].append(time)
-        trajectory["unique_ids"].append([])
-        trajectory["type_names"].append([])
-        trajectory["n_subpoints"].append([])
-        trajectory["subpoints"].append([])
-        for fiber_id in fibers:
-            fiber = fibers[fiber_id]
-            fiber_points = [
-                np.array(point) + position_offset for point in fiber["points"]
-            ]
-            n_agents += 1
-            trajectory["unique_ids"][time_index].append(int(fiber_id))
-            trajectory["type_names"][time_index].append(fiber["type_name"])
-            trajectory["n_subpoints"][time_index].append(len(fiber_points))
-            trajectory["subpoints"][time_index].append(fiber_points)
-        trajectory["n_agents"].append(n_agents)
-        trajectory["viz_types"].append(n_agents * [1001.0])
-        trajectory["positions"].append(n_agents * [[0.0, 0.0, 0.0]])
-        trajectory["radii"].append(n_agents * [actin_radius])
-        return trajectory
-
-    def get_simularium_monomers(
-        self, time, monomers, actin_radius, position_offset, trajectory
-    ):
+    def get_simularium_monomers(self, time, monomers, trajectory):
         """
         Shape monomer state data into Simularium agents
         """
@@ -84,15 +42,21 @@ class SimulariumEmitter(Emitter):
         trajectory["unique_ids"].append([])
         trajectory["type_names"].append([])
         trajectory["positions"].append([])
+        trajectory["radii"].append([])
         edge_ids = []
         edge_positions = []
-        for particle_id in monomers.get("particles", {}):
+        for particle_id in monomers["particles"]:
             particle = monomers["particles"][particle_id]
             trajectory["unique_ids"][time_index].append(int(particle_id))
             trajectory["type_names"][time_index].append(particle["type_name"])
-            trajectory["positions"][time_index].append(
-                np.array(particle["position"]) + position_offset
-            )
+            # HACK needed until simulariumio default display data fix
+            if particle["type_name"] not in trajectory["display_data"]:
+                trajectory["display_data"][particle["type_name"]] = DisplayData(
+                    name=particle["type_name"],
+                    display_type=DISPLAY_TYPE.SPHERE,
+                )
+            trajectory["positions"][time_index].append(np.array(particle["position"]))
+            trajectory["radii"][time_index].append(particle["radius"])
             # visualize edges between particles
             for neighbor_id in particle["neighbor_ids"]:
                 neighbor_id_str = str(neighbor_id)
@@ -105,9 +69,10 @@ class SimulariumEmitter(Emitter):
                     edge_ids.append(edge)
                     edge_positions.append(
                         [
-                            np.array(particle["position"]) + position_offset,
-                            np.array(monomers["particles"][neighbor_id_str]["position"])
-                            + position_offset,
+                            np.array(particle["position"]),
+                            np.array(
+                                monomers["particles"][neighbor_id_str]["position"]
+                            ),
                         ]
                     )
         n_agents = len(trajectory["unique_ids"][time_index])
@@ -118,7 +83,6 @@ class SimulariumEmitter(Emitter):
         trajectory["unique_ids"][time_index] += [1000 + i for i in range(n_edges)]
         trajectory["type_names"][time_index] += ["edge" for edge in range(n_edges)]
         trajectory["positions"][time_index] += n_edges * [[0.0, 0.0, 0.0]]
-        trajectory["radii"].append(n_agents * [actin_radius])
         trajectory["radii"][time_index] += n_edges * [1.0]
         trajectory["n_subpoints"].append(n_agents * [0])
         trajectory["n_subpoints"][time_index] += n_edges * [2]
@@ -143,7 +107,9 @@ class SimulariumEmitter(Emitter):
         """
         Shape a jagged list with 3 dimensions to a numpy array
         """
-        df = SimulariumEmitter.fill_df(pd.DataFrame(jagged_3d_list), [0.0, 0.0, 0.0])
+        df = SimulariumMonomerEmitter.fill_df(
+            pd.DataFrame(jagged_3d_list), [0.0, 0.0, 0.0]
+        )
         df_t = df.transpose()
         exploded = [df_t[col].explode() for col in list(df_t.columns)]
         return np.array(exploded).reshape((df.shape[0], df.shape[1], 3))
@@ -158,7 +124,7 @@ class SimulariumEmitter(Emitter):
         max_subpoints = 0
         total_steps = len(trajectory["subpoints"])
         for time_index in range(total_steps):
-            frame_array = SimulariumEmitter.jagged_3d_list_to_numpy_array(
+            frame_array = SimulariumMonomerEmitter.jagged_3d_list_to_numpy_array(
                 trajectory["subpoints"][time_index]
             )
             if frame_array.shape[0] > max_agents:
@@ -184,70 +150,60 @@ class SimulariumEmitter(Emitter):
         Shape a dictionary of jagged lists into a Simularium AgentData object
         """
         return AgentData(
-            times=np.arange(len(trajectory["times"])),
+            times=trajectory["times"],
             n_agents=np.array(trajectory["n_agents"]),
-            viz_types=SimulariumEmitter.fill_df(
+            viz_types=SimulariumMonomerEmitter.fill_df(
                 pd.DataFrame(trajectory["viz_types"]), 1000.0
             ).to_numpy(),
-            unique_ids=SimulariumEmitter.fill_df(
+            unique_ids=SimulariumMonomerEmitter.fill_df(
                 pd.DataFrame(trajectory["unique_ids"]), 0
             ).to_numpy(dtype=int),
             types=trajectory["type_names"],
             positions=scale_factor
-            * SimulariumEmitter.jagged_3d_list_to_numpy_array(trajectory["positions"]),
+            * SimulariumMonomerEmitter.jagged_3d_list_to_numpy_array(
+                trajectory["positions"]
+            ),
             radii=scale_factor
-            * SimulariumEmitter.fill_df(
+            * SimulariumMonomerEmitter.fill_df(
                 pd.DataFrame(trajectory["radii"]), 0.0
             ).to_numpy(),
-            n_subpoints=SimulariumEmitter.fill_df(
+            n_subpoints=SimulariumMonomerEmitter.fill_df(
                 pd.DataFrame(trajectory["n_subpoints"]), 0
             ).to_numpy(dtype=int),
             subpoints=scale_factor
-            * SimulariumEmitter.get_subpoints_numpy_array(trajectory),
+            * SimulariumMonomerEmitter.get_subpoints_numpy_array(trajectory),
+            display_data=trajectory["display_data"],
         )
 
     @staticmethod
     def get_simularium_converter(
-        trajectory, box_dimensions, scale_factor
+        trajectory, box_dimensions, scale_factor, time_units, spatial_units
     ) -> TrajectoryConverter:
         """
         Shape a dictionary of jagged lists into a Simularium TrajectoryData object
         and provide it to a TrajectoryConverter for conversion
         """
-        spatial_units = UnitData("nm")
         spatial_units.multiply(1 / scale_factor)
         return TrajectoryConverter(
             TrajectoryData(
                 meta_data=MetaData(
                     box_size=scale_factor * box_dimensions,
                 ),
-                agent_data=SimulariumEmitter.get_agent_data_from_jagged_lists(
+                agent_data=SimulariumMonomerEmitter.get_agent_data_from_jagged_lists(
                     trajectory, scale_factor
                 ),
-                time_units=UnitData("count"),
+                time_units=time_units,
                 spatial_units=spatial_units,
             )
         )
-
-    @staticmethod
-    def get_active_choice(choices) -> Tuple[str, bool]:
-        """
-        Determine the active simulator
-        """
-        for choice in choices:
-            if choices[choice]:
-                return choice
-        return None
 
     def get_data(self) -> dict:
         """
         Save the accumulated timeseries history of "emitted" data to file
         """
-        if "readdy_actin" in self.configuration_data:
-            actin_radius = self.configuration_data["readdy_actin"]["actin_radius"]
-        else:
-            actin_radius = 3.0  # TODO add to MEDYAN/Cytosim configs
-        box_dimensions = None
+        box_size = None
+        time_units = None
+        spatial_units = None
         trajectory = {
             "times": [],
             "n_agents": [],
@@ -258,37 +214,22 @@ class SimulariumEmitter(Emitter):
             "radii": [],
             "n_subpoints": [],
             "subpoints": [],
+            "display_data": {},
         }
-        times = list(self.saved_data.keys())
-        times.sort()
-        vizualize_time_index = 0
-        for time, state in self.saved_data.items():
-            index = times.index(time)
-            current_choice = SimulariumEmitter.get_active_choice(state["choices"])
-            if box_dimensions is None and "fibers_box_extent" in state:
-                box_dimensions = np.array(state["fibers_box_extent"])
-            if VIZ_FOR_CHOICE[current_choice] == "fibers":
-                center_fibers = (
-                    index == 0 or "readdy_active" in state["choices"]
-                )  # TODO generalize
-                trajectory = self.get_simularium_fibers(
-                    vizualize_time_index,
-                    state["fibers"],
-                    actin_radius,
-                    -0.5 * box_dimensions if center_fibers else np.zeros(3),
-                    trajectory,
-                )
-                vizualize_time_index += 1
-            if VIZ_FOR_CHOICE[current_choice] == "monomers":
-                trajectory = self.get_simularium_monomers(
-                    vizualize_time_index,
-                    state["monomers"],
-                    actin_radius,
-                    (np.array(state["monomers"]["box_center"]) - 0.5 * box_dimensions),
-                    trajectory,
-                )
-                vizualize_time_index += 1
-        simularium_converter = SimulariumEmitter.get_simularium_converter(
-            trajectory, box_dimensions, 0.1
+        for state in self.saved_data:
+            if box_size is None:
+                box_size = state["monomers"]["box_size"]
+            if time_units is None:
+                time_units = state["time_units"]
+            if spatial_units is None:
+                spatial_units = state["spatial_units"]
+            trajectory = self.get_simularium_monomers(
+                state["time"],
+                state["monomers"],
+                trajectory,
+            )
+        simularium_converter = SimulariumMonomerEmitter.get_simularium_converter(
+            trajectory, box_size, 0.1, UnitData(time_units), UnitData(spatial_units)
         )
-        simularium_converter.write_JSON("out/actin_test")
+        simularium_converter.save("out/test")
+        return {"simularium_converter": simularium_converter}

--- a/vivarium_readdy/util.py
+++ b/vivarium_readdy/util.py
@@ -1,0 +1,94 @@
+import numpy as np
+
+
+monomer_ports_schema = {
+    "time_units": {
+        "_default": "s",
+        "_updater": "set",
+        "_emit": True,
+    },
+    "spatial_units": {
+        "_default": "m",
+        "_updater": "set",
+        "_emit": True,
+    },
+    "monomers": {
+        "box_center": {
+            "_default": np.array([0.0, 0.0, 0.0]),
+            "_updater": "set",
+            "_emit": True,
+        },
+        "box_size": {
+            "_default": 500.0,
+            "_updater": "set",
+            "_emit": True,
+        },
+        "topologies": {
+            "*": {
+                "type_name": {
+                    "_default": "",
+                    "_updater": "set",
+                    "_emit": True,
+                },
+                "particle_ids": {
+                    "_default": [],
+                    "_updater": "set",
+                    "_emit": True,
+                },
+            }
+        },
+        "particles": {
+            "*": {
+                "type_name": {
+                    "_default": "",
+                    "_updater": "set",
+                    "_emit": True,
+                },
+                "position": {
+                    "_default": np.zeros(3),
+                    "_updater": "set",
+                    "_emit": True,
+                },
+                "neighbor_ids": {
+                    "_default": [],
+                    "_updater": "set",
+                    "_emit": True,
+                },
+                "radius": {
+                    "_default": 1.0,
+                    "_updater": "set",
+                    "_emit": True,
+                },
+            }
+        },
+    },
+}
+
+
+def agents_update(existing, projected):
+    update = {"_add": [], "_delete": []}
+
+    for id, state in projected.items():
+        if id in existing:
+            update[id] = state
+        else:
+            update["_add"].append({"key": id, "state": state})
+
+    for existing_id in existing.keys():
+        if existing_id not in projected:
+            update["_delete"].append(existing_id)
+
+    return update
+
+
+def create_monomer_update(previous_monomers, new_monomers):
+    return {
+        "monomers": {
+            "topologies": agents_update(
+                previous_monomers["topologies"], new_monomers["topologies"]
+            ),
+            "particles": agents_update(
+                previous_monomers["particles"], new_monomers["particles"]
+            ),
+        }
+    }


### PR DESCRIPTION
Problem
=======
We're working on visualizing a simple ReaDDy model (https://github.com/simularium/vivarium-models/issues/19) in Simularium as it calculates live, and we need updates to the ports structure and emitter in order to convert data for SImularium in the same way we visualize actin models from ReaDDy.

Solution
========
Updated the ports structure to match other ReaDDy processes, made implementation more general wrt scale and system, and updated the emitter accordingly.

## Type of change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

Change summary:
---------------
* use the ports schema for monomers from our models collab repo (https://github.com/simularium/vivarium-models), so we can handle all data from ReaDDy similarly
* add time and space units to support other scales, since ReaDDy can use any units as long as they are consistent. generalize diffusion coefficient calculation to match
* only create the ReaDDy system at init and reuse it for each simulation step. Previously it was created every timestep. This is a huge gain in efficiency and the tradeoff is that all the particle species have to be declared at start
* add visualization radius to particle state data so it doesn't need to be hardcoded in the emitter
* some code clean up
